### PR TITLE
CircleCi integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,6 @@ jobs:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
-      # Database setup
-      - run: bundle exec rake db:create
-      - run: bundle exec rake db:schema:load
-
       # run tests!
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,57 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.4.1-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      # Database setup
+      - run: bundle exec rake db:create
+      - run: bundle exec rake db:schema:load
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+
+            ./bin/run_tests
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ after_success:
 
 env:
   matrix:
-    - "RAILS_VERSION=4.1"
     - "RAILS_VERSION=4.2"
     - "RAILS_VERSION=5.0"
     - "RAILS_VERSION=5.1"

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+rcommand='puts YAML.load_file("./.travis.yml")["env"]["matrix"].join(" ").gsub("RAILS_VERSION=", "")'
+versions=$(ruby -ryaml -e "$rcommand")
+
+for version in ${versions[@]}; do
+  export RAILS_VERSION="$version"
+  rm -f Gemfile.lock
+  bundle check || bundle --local || bundle
+  bundle exec rake test
+  if [ "$?" -eq 0 ]; then
+    # green in ANSI
+    echo -e "\033[32m **** Tests passed against Rails ${RAILS_VERSION} **** \033[0m"
+  else
+    # red in ANSI
+    echo -e "\033[31m **** Tests failed against Rails ${RAILS_VERSION} **** \033[0m"
+    read -p '[Enter] any key to continue, [q] to quit...' prompt
+    if [ "$prompt" = 'q' ]; then
+      unset RAILS_VERSION
+      exit 1
+    fi
+fi
+  unset RAILS_VERSION
+done

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -14,11 +14,8 @@ for version in ${versions[@]}; do
   else
     # red in ANSI
     echo -e "\033[31m **** Tests failed against Rails ${RAILS_VERSION} **** \033[0m"
-    read -p '[Enter] any key to continue, [q] to quit...' prompt
-    if [ "$prompt" = 'q' ]; then
-      unset RAILS_VERSION
-      exit 1
-    fi
+    unset RAILS_VERSION
+    exit 1
 fi
   unset RAILS_VERSION
 done


### PR DESCRIPTION
We are forking this repo following our need to activate `cache_versioning` on our rails apps and the missing support the current active_model_serializer gem give use. A Pull Request has been opened on the original repo and in the meantime, we decided to fork the gem repo and apply the change there. 

More informations can be found here on why we are forking: https://github.com/cookpad/global-web/pull/9436

This PR adds a script to run the tests in all supported versions of rails on CircleCi. 
Tests were already broken for Rails 4.1, so I removed that as a supported version for this fork. 
The script is a slightly modified version of the script used here: https://github.com/cookpad/active_model_serializers/blob/master/CONTRIBUTING.md#contributing where the only change is the `exit 1` without waiting for a pronpted response in circleCi https://github.com/cookpad/active_model_serializers/pull/2/files#diff-2f39a8464db2dbee6055fc09db08e61bR18