### PR TITLE
Fixes to travis integration 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - "RAILS_VERSION=4.2"
     - "RAILS_VERSION=5.0"
     - "RAILS_VERSION=5.1"
+    - "RAILS_VERSION=5.2"
     - "RAILS_VERSION=master"
 
 rvm:
@@ -29,6 +30,10 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
+
+branches:
+  only:
+  - 0-10-stable
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
   - { rvm: 2.3.5,        env: RAILS_VERSION=master }
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.0 }
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.1 }
+  - { rvm: 2.1.10,        env: RAILS_VERSION=5.2 }
   - { rvm: 2.4.2,         env: RAILS_VERSION=4.1 }
   - { rvm: ruby-head,     env: RAILS_VERSION=4.1 }
   allow_failures:


### PR DESCRIPTION
This add 5.2 in the list of supported rails versions and exclude it to run with ruby < 2.2 versions. 